### PR TITLE
Implement #19:CASCADE and CASCADE.2.

### DIFF
--- a/lib/ctrl.js
+++ b/lib/ctrl.js
@@ -57,6 +57,12 @@ export default {
             "crossmap": {jsFunc: primitiveCrossmap, formal: "template [inputs] 2",
                 attributes: PROC_ATTRIBUTE.STASH_LOCAL_VAR | PROC_ATTRIBUTE.RETURNS_IN_LAMBDA},
 
+            "cascade": {jsFunc: primitiveCascade, formal: "template [inputs] 3",
+                attributes: PROC_ATTRIBUTE.STASH_LOCAL_VAR | PROC_ATTRIBUTE.RETURNS_IN_LAMBDA},
+
+            "cascade.2": {jsFunc: primitiveCascade, formal: "template [inputs] 5",
+                attributes: PROC_ATTRIBUTE.STASH_LOCAL_VAR | PROC_ATTRIBUTE.RETURNS_IN_LAMBDA},
+
             "filter": {jsFunc: primitiveFilter, attributes: PROC_ATTRIBUTE.STASH_LOCAL_VAR | PROC_ATTRIBUTE.RETURNS_IN_LAMBDA},
 
             "find": {jsFunc: primitiveFind, attributes: PROC_ATTRIBUTE.STASH_LOCAL_VAR | PROC_ATTRIBUTE.RETURNS_IN_LAMBDA},
@@ -86,7 +92,7 @@ export default {
             }
 
             if (logo.type.isLogoWord(template)) {
-                return await logo.env.applyNamedProcedure(template.toLowerCase(), srcmap, slot, inputListSrcmap);
+                return await logo.env.applyNamedProcedure(logo.type.toString(template).toLowerCase(), srcmap, slot, inputListSrcmap);
             }
 
             logo.type.validateInputList(template);
@@ -202,6 +208,62 @@ export default {
 
             function prependEach(elem, array) { // (4, [[1], [2]]) => [[4, 1], [4, 2]]
                 return array.map((val) => [].concat(elem, val));
+            }
+        }
+
+        async function primitiveCascade(...args) {
+            let [endTestInput, template, value, finalTemplate] = getCascadeInputs();
+
+            if (logo.type.isNonNegInteger(endTestInput)) {
+                let loopCount = Number(endTestInput);
+                return await cascadeHelper((i) => i < loopCount);
+            }
+
+            return await cascadeHelper(async (i) =>
+                !logo.type.isLogoBooleanTrue(await applyHelper(endTestInput, logo.type.makeLogoList(value), i + 1)));
+
+            async function cascadeHelper(endTest) {
+                let i = 0;
+                for (; await endTest(i); i++) {
+                    value = await evaluateNextValue(value, i + 1);
+                }
+
+                return evaluateFinalValue(i + 1);
+            }
+
+            async function evaluateFinalValue(index) {
+                if (finalTemplate === undefined) {
+                    return value[0];
+                }
+
+                return await applyHelper(finalTemplate, logo.type.makeLogoList(value), index);
+            }
+
+            async function evaluateNextValue(value, index) {
+                let nextValue = [];
+                for (let j = 0; j < value.length; j++) {
+                    nextValue.push(await applyHelper(template[j], logo.type.makeLogoList(value), index));
+                }
+
+                return nextValue;
+            }
+
+            function getCascadeInputs() {
+                let endTest = args.shift();
+                let finalTemplate = undefined;
+                if (args.length % 2 === 1) {
+                    finalTemplate = args.pop();
+                }
+
+                let template = [];
+                let startValue = [];
+
+                for (let i = 0; i < args.length / 2; i++) {
+                    template.push(args[2 * i]);
+                    startValue.push(args[2 * i + 1]);
+                }
+
+                return [endTest, template, startValue, finalTemplate];
             }
         }
 

--- a/unittests/primitives/cascade.2.lgo
+++ b/unittests/primitives/cascade.2.lgo
@@ -1,0 +1,35 @@
+to test2 :v
+output :v > 2
+end
+
+TO VOWELP :arg
+IF :arg="a [OUTPUT "true]
+IF :arg="e [OUTPUT "true]
+IF :arg="i [OUTPUT "true]
+IF :arg="o [OUTPUT "true]
+IF :arg="u [OUTPUT "true]
+OUTPUT "false
+END
+
+to fibonacci :n
+output cascade.2 :n [?1 + ?2] 1 [?1] 0
+end
+
+to piglatin :word
+output (cascade.2 [vowelp first ?] ~
+                [word bf ? first ?] ~
+                :word ~
+                [word ? "ay])
+end
+
+show (cascade.2 0 [] 1)
+show (cascade.2 ["true] [] 2)
+show (cascade.2 "test2 [? + 1] 1)
+show (cascade.2 2 [?+1] 1 [?+#])
+
+show (cascade.2 5 [lput # ?] [])
+show (cascade.2 [vowelp first ?] [bf ?] "spring)
+show (cascade.2 5 [# * ?] 1)
+
+show map "fibonacci (iseq 1 10)
+show map "piglatin [The quick fox jumps over the lazy dog]

--- a/unittests/primitives/cascade.2.out
+++ b/unittests/primitives/cascade.2.out
@@ -1,0 +1,9 @@
+1
+2
+3
+6
+[1 2 3 4 5]
+ing
+120
+[1 2 3 5 8 13 21 34 55 89]
+[eThay uickqay oxfay umpsjay overay ethay azylay ogday]

--- a/unittests/primitives/cascade.2_err.err
+++ b/unittests/primitives/cascade.2_err.err
@@ -1,0 +1,30 @@
+Not enough inputs to cascade.2
+    at 1,10	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 2,15	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 3,17	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 4,18	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 5,20	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 6,17	cascade.2_err.lgo
+cascade.2 doesn't like {} as input
+    at 7,2	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 9,17	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 10,23	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 11,27	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 12,26	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 14,26	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 15,42	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 16,22	cascade.2_err.lgo
+Not enough inputs to cascade.2
+    at 17,65	cascade.2_err.lgo

--- a/unittests/primitives/cascade.2_err.lgo
+++ b/unittests/primitives/cascade.2_err.lgo
@@ -1,0 +1,17 @@
+cascade.2
+cascade.2 1 []
+cascade.2 1 {} 1
+cascade.2 {} [] 1
+cascade.2 [?>2] 1 1
+cascade.2 2 {} 1
+(cascade.2 2 [?+1] 1 {})
+
+cascade.2 0 [] 1
+cascade.2 ["true] [] 2
+cascade.2 "test2 [? + 1] 1
+cascade.2 2 [?+1] 1 [?+#]
+
+cascade.2 5 [lput # ?] []
+cascade.2 [vowelp first ?] [bf ?] "spring
+cascade.2 5 [# * ?] 1
+cascade.2 [vowelp first ?] [word bf ? first ?] "fox [word ? "ay]

--- a/unittests/primitives/cascade.lgo
+++ b/unittests/primitives/cascade.lgo
@@ -1,0 +1,35 @@
+to test2 :v
+output :v > 2
+end
+
+TO VOWELP :arg
+IF :arg="a [OUTPUT "true]
+IF :arg="e [OUTPUT "true]
+IF :arg="i [OUTPUT "true]
+IF :arg="o [OUTPUT "true]
+IF :arg="u [OUTPUT "true]
+OUTPUT "false
+END
+
+to fibonacci :n
+output (cascade :n [?1 + ?2] 1 [?1] 0)
+end
+
+to piglatin :word
+output (cascade [vowelp first ?] ~
+                [word bf ? first ?] ~
+                :word ~
+                [word ? "ay])
+end
+
+show cascade 0 [] 1
+show cascade ["true] [] 2
+show cascade "test2 [? + 1] 1
+show (cascade 2 [?+1] 1 [?+#])
+
+show cascade 5 [lput # ?] []
+show cascade [vowelp first ?] [bf ?] "spring
+show cascade 5 [# * ?] 1
+
+show map "fibonacci (iseq 1 10)
+show map "piglatin [The quick fox jumps over the lazy dog]

--- a/unittests/primitives/cascade.out
+++ b/unittests/primitives/cascade.out
@@ -1,0 +1,9 @@
+1
+2
+3
+6
+[1 2 3 4 5]
+ing
+120
+[1 2 3 5 8 13 21 34 55 89]
+[eThay uickqay oxfay umpsjay overay ethay azylay ogday]

--- a/unittests/primitives/cascade_err.err
+++ b/unittests/primitives/cascade_err.err
@@ -1,0 +1,14 @@
+Not enough inputs to cascade
+    at 1,8	cascade_err.lgo
+Not enough inputs to cascade
+    at 2,13	cascade_err.lgo
+cascade doesn't like {} as input
+    at 3,1	cascade_err.lgo
+cascade doesn't like {} as input
+    at 4,1	cascade_err.lgo
+I don't know how to 1
+    at 5,1	cascade_err.lgo
+cascade doesn't like {} as input
+    at 6,1	cascade_err.lgo
+cascade doesn't like {} as input
+    at 7,2	cascade_err.lgo

--- a/unittests/primitives/cascade_err.lgo
+++ b/unittests/primitives/cascade_err.lgo
@@ -1,0 +1,7 @@
+cascade
+cascade 1 []
+cascade 1 {} 1
+cascade {} [] 1
+cascade [?>2] 1 1
+cascade 2 {} 1
+(cascade 2 [?+1] 1 {})

--- a/unittests/primitives/keyboardon_err.err
+++ b/unittests/primitives/keyboardon_err.err
@@ -9,8 +9,8 @@ keyboardon doesn't like {} as input
 keyboardon doesn't like {} as input
     at 6,2	keyboardon_err.lgo
 I don't know how to on_key_down
-    at 8,1	keyboardon_err.lgo
+    at 8,13	keyboardon_err.lgo
 I don't know how to on_key_down
-    at 11,2	keyboardon_err.lgo
+    at 11,14	keyboardon_err.lgo
 I don't know how to on_key_up
-    at 11,2	keyboardon_err.lgo
+    at 11,28	keyboardon_err.lgo

--- a/unittests/primitives/keyboardon_err.lgo
+++ b/unittests/primitives/keyboardon_err.lgo
@@ -5,9 +5,9 @@ keyboardon {}
 (keyboardon []{})
 (keyboardon {}[])
 
-keyboardon "on_key_down
+keyboardon [on_key_down]
 ;turtle keyboard down A keyA
 
-(keyboardon "on_key_down "on_key_up)
+(keyboardon [on_key_down] [on_key_up])
 ;turtle keyboard down A KeyA
 ;turtle keyboard up A KeyA

--- a/unittests/primitives/list.txt
+++ b/unittests/primitives/list.txt
@@ -172,3 +172,7 @@ find exec run
 find_err execl runl
 crossmap exec run
 crossmap_err execl runl
+cascade exec run
+cascade_err execl runl
+cascade.2 exec run
+cascade.2_err execl runl

--- a/unittests/primitives/mouseon_err.err
+++ b/unittests/primitives/mouseon_err.err
@@ -21,14 +21,14 @@ mouseon doesn't like {} as input
 mouseon doesn't like {} as input
     at 12,1	mouseon_err.lgo
 I don't know how to on_mouse_move
-    at 14,1	mouseon_err.lgo
+    at 14,92	mouseon_err.lgo
 I don't know how to on_left_mouse_down
-    at 14,1	mouseon_err.lgo
+    at 14,10	mouseon_err.lgo
 I don't know how to on_left_mouse_up
-    at 14,1	mouseon_err.lgo
+    at 14,31	mouseon_err.lgo
 I don't know how to on_mouse_move
-    at 14,1	mouseon_err.lgo
+    at 14,92	mouseon_err.lgo
 I don't know how to on_right_mouse_down
-    at 14,48	mouseon_err.lgo
+    at 14,50	mouseon_err.lgo
 I don't know how to on_right_mouse_up
-    at 14,70	mouseon_err.lgo
+    at 14,72	mouseon_err.lgo

--- a/unittests/primitives/mouseon_err.lgo
+++ b/unittests/primitives/mouseon_err.lgo
@@ -11,7 +11,7 @@ mouseon [][]{}[][]
 mouseon []{}[][][]
 mouseon {}[][][][]
 
-mouseon "on_left_mouse_down "on_left_mouse_up [on_right_mouse_down] [on_right_mouse_up] "on_mouse_move
+mouseon [on_left_mouse_down] [on_left_mouse_up] [on_right_mouse_down] [on_right_mouse_up] [on_mouse_move]
 ;turtle mouse move 0 1
 ;turtle mouse down -101.2 99.1 0
 ;turtle mouse up -110.7 -1.1 0


### PR DESCRIPTION
CASCADE endtest template startvalue
(CASCADE endtest tmp1 sv1 tmp2 sv2 ...)
(CASCADE endtest tmp1 sv1 tmp2 sv2 ... finaltemplate)

CASCADE.2 endtest temp1 startval1 temp2 startval2
outputs the result of invoking CASCADE with the same inputs. The only difference is that
the default number of inputs is five instead of three.

    outputs the result of applying a template (or several templates,
    as explained below) repeatedly, with a given value filling the
    slot the first time, and the result of each application filling
    the slot for the following application.

    In the simplest case, CASCADE has three inputs.  The second input
    is a one-slot expression template.  That template is evaluated
    some number of times (perhaps zero).  On the first evaluation,
    the slot is filled with the third input; on subsequent evaluations,
    the slot is filled with the result of the previous evaluation.
    The number of evaluations is determined by the first input.  This
    can be either a nonnegative integer, in which case the template is
    evaluated that many times, or a predicate expression template, in
    which case it is evaluated (with the same slot filler that will be
    used for the evaluation of the second input) repeatedly, and the
    CASCADE evaluation continues as long as the predicate value is
    FALSE.  (In other words, the predicate template indicates the
    condition for stopping.)

    If the template is evaluated zero times, the output from CASCADE
    is the third (startvalue) input.  Otherwise, the output is the
    value produced by the last template evaluation.

    CASCADE templates may include the symbol # to represent the number
    of times the template has been evaluated.  This slot is filled with
    1 for the first evaluation, 2 for the second, and so on.

            ? show cascade 5 [lput # ?] []
            [1 2 3 4 5]
            ? show cascade [vowelp first ?] [bf ?] "spring
            ing
            ? show cascade 5 [# * ?] 1
            120
            ?

    Several cascaded results can be computed in parallel by providing
    additional template-startvalue pairs as inputs to CASCADE.  In this
    case, all templates (including the endtest template, if used) are
    multi-slot, with the number of slots equal to the number of pairs of
    inputs.  In each round of evaluations, ?2, for example, represents the
    result of evaluating the second template in the previous round.  If
    the total number of inputs (including the first endtest input) is odd,
    then the output from CASCADE is the final value of the first template.
    If the total number of inputs is even, then the last input is a
    template that is evaluated once, after the end test is satisfied, to
    determine the output from CASCADE.

            to fibonacci :n
            output (cascade :n [?1 + ?2] 1 [?1] 0)
            end

            to piglatin :word
            output (cascade [vowelp first ?] ~
                            [word bf ? first ?] ~
                            :word ~
                            [word ? "ay])
            end