### PR TITLE
Add ERASEFILE, UNERASEFILE, LOADEDIT, SAVEEDIT, LISTFILE for web.

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -42,6 +42,8 @@ export default {
         NOT_SAME_LENGTH       : [1022, "Inputs of {0} have different lengths"],
         TOO_MANY_INPUTS       : [1023, "Too many inputs to {0}"],
         LAST_ERROR_CODE       : [1024],
+        FILE_NOT_FOUND        : [65529, "File {0} not found."],
+        FILE_EXISTS           : [65530, "File {0} exists."],
         NO_HELP_AVAILABLE     : [65531, "No help available on {0}."],
         CUSTOM                : [65532, "Can't find catch tag for {0}"],
         OUTPUT                : [65534, "Can only use output inside a procedure"],

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -14,6 +14,22 @@ export default {
 
             "demo": primitiveDemo,
 
+            "loadedit": primitiveLoadedit,
+            "lde": primitiveLoadedit,
+
+            "saveedit": primitiveSaveedit,
+            "sae": primitiveSaveedit,
+
+            "listfile": [primitiveListfile, "[pattern .novalue]"],
+            "ls": [primitiveListfile, "[pattern .novalue]"],
+            "dir": [primitiveListfile, "[pattern .novalue]"],
+            "catalog": [primitiveListfile, "[pattern .novalue]"],
+
+            "erasefile": primitiveErasefile,
+            "erf": primitiveErasefile,
+
+            "unerasefile": primitiveUnerasefile,
+
             ".test": dotTest
         };
         misc.methods = methods;
@@ -36,6 +52,47 @@ export default {
             }
 
             await logo.env.logoExec(src, "/demo/" + demoFileName);
+        }
+
+        async function primitiveSaveedit(fileName) {
+            let success = await logo.io.call("editorSaveToLocalStorage", fileName);
+            if (!success) {
+                throw logo.type.LogoException.CANNOT_OVERWRITE_FILE.withParam([fileName], logo.env.getProcSrcmap());
+            }
+        }
+
+        async function primitiveLoadedit(fileName) {
+            let success = await logo.io.call("editorLoadFromLocalStorage", fileName);
+            if (!success) {
+                throw logo.type.LogoException.FILE_NOT_FOUND.withParam([fileName], logo.env.getProcSrcmap());
+            }
+        }
+
+        async function primitiveListfile(pattern = undefined) {
+            let fileList = await logo.io.call("listFilesInLocalStorage");
+            if (pattern !== undefined) {
+                fileList = fileList.filter((fileName) => fileName.indexOf(pattern)!= -1);
+            }
+
+            logo.io.call("out", fileList.join("\n"));
+        }
+
+        async function primitiveErasefile(fileName) {
+            let success = await logo.io.call("eraseFileInLocalStorage", fileName);
+            if (!success) {
+                throw logo.type.LogoException.FILE_NOT_FOUND.withParam([fileName], logo.env.getProcSrcmap());
+            }
+        }
+
+        async function primitiveUnerasefile(fileName) {
+            if (await logo.io.call("fileExistsInLocalStorage", fileName)) {
+                throw logo.type.LogoException.FILE_EXISTS.withParam([fileName], logo.env.getProcSrcmap());
+            }
+
+            let success = await logo.io.call("uneraseFileInLocalStorage", fileName);
+            if (!success) {
+                throw logo.type.LogoException.FILE_NOT_FOUND.withParam([fileName], logo.env.getProcSrcmap());
+            }
         }
 
         async function dotTest(testName, testMethod) {


### PR DESCRIPTION
ERASEFILE filename
ERF filename
        Erases (deletes, removes) the named file, which should not
        currently be open.

UNERASEFILE filename
        Unerases (undeletes, recovers) the named file, which should
        have been erased by ERASEFILE but not overwritten by new files.

LOADEDIT filename
LDE filename
        Reads the named file to the editor.

SAVEEDIT filename
SAE filename
        Saves the content in the editor to the named file.

LISTFILE
(LISTFILE pattern)
LS
(LS pattern)
DIR
(DIR pattern)
CATALOG
(CATALOG pattern)
         List files saved by SAVEEDIT. If pattern is present,
         only list files that contains pattern in the file names
         as their substrings.

        